### PR TITLE
Short-Circuit Choose and Fix typos

### DIFF
--- a/monsql/wrapper.py
+++ b/monsql/wrapper.py
@@ -263,13 +263,14 @@ class MonSQL:
         self.__cursor.execute(sql)
         self.__db.commit()
 
-    def drop_table(self, tablename, slient=False):
+    def drop_table(self, tablename, silent=False):
         """
         Drop a table
         tablename: string
-        slient: boolean. When the table doesn't exists, this be False will raise an exception; otherwise no action will be taken
+        silent: boolean. If false and the table doesn't exists an exception will be raised;
+          Otherwise it will be ignored
         """
-        if not self.is_table_existed(tablename) and not slient:
+        if not silent and not self.is_table_existed(tablename):
             raise MonSQLException('TABLE %s DOES NOT EXIST' %tablename)
 
         self.__cursor.execute('DROP TABLE IF EXISTS %s' %(tablename))


### PR DESCRIPTION
When `monsql.drop_table` is invoked, internally we first evaluate
`silent`. If it is true, we continue to evaluate `.is_table_existed`.
If false, we ignore the second evaluation.This will avoid accessing
the database (in evaluating `.is_table_existed`) everytime
`monsql.drop_table` is invoked.

For more information on short-circuit operators, see
https://docs.python.org/2/library/stdtypes.html#boolean-operations-and-or-not

Some minor typo errors are fixed. `silent` was mispelled as `slient`.
