### PR TITLE
Some minor corrections

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2014-2015 Taiyuan Zhang <taiyuanz@taiyuans-mbp.wv.cc.cmu.edu>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -72,3 +72,9 @@ More info in the issue page
 
 The tests scripts in based on tests/config.yml file. Take a look at the tests/config.yml.orig and modify it to suite your need.
 
+
+## license:
+
+__The MIT License (MIT)__
+
+Copyright (c) 2014-2015 Taiyuan Zhang <taiyuanz@taiyuans-mbp.wv.cc.cmu.edu>

--- a/monsql/query.py
+++ b/monsql/query.py
@@ -79,7 +79,7 @@ class QueryCondition:
 
         """
         condition = self.condition
-        if condition is not None and len(condition.items()) > 0:
+        if condition:
             keys = condition.keys()
             if len(keys) > 1:
                 split_conditions = []


### PR DESCRIPTION
License Information has been updated.

As commented in commit 1b90019:

> An empty dictionary evaluates to False in a boolean context. If not empty it evaluates to True instead.
> Using `if a_dict: ...` is pythonic rather than being explicit.
> 
> For more information, see https://www.python.org/dev/peps/pep-0008/#programming-recommendations
