### PR TITLE
Continuous Integration with Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build/
 *egg-info*
 dist/
 .DS_Store
-*.yml
+tests/config.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ env:
   - TARGET_DATABASES=MySQL DB_TYPE=MySQL MYSQL_HOST="127.0.0.1" MYSQL_PORT=3306 MYSQL_USER=root MYSQL_PASSWORD="" MYSQL_DB=testing
   - TARGET_DATABASES=SQLite3 DB_TYPE=SQLite3 SQLITE3_PATH=":memory:"
 
-install: make reqs
+install: sudo make reqs
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+python:
+  - "2.7"
+
+services:
+  - mysql
+  - sqlite3
+
+env:
+  - TARGET_DATABASES=MySQL DB_TYPE=MySQL MYSQL_HOST="127.0.0.1" MYSQL_PORT=3306 MYSQL_USER=root MYSQL_PASSWORD="" MYSQL_DB=testing
+  - TARGET_DATABASES=SQLite3 DB_TYPE=SQLite3 SQLITE3_PATH=":memory:"
+
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,7 @@ env:
 
 install: sudo make reqs
 
+before_script:
+  - sh -c "if [ $DB_TYPE = 'MySQL' ] ; then mysql -e 'create database IF NOT EXISTS testing;' ; fi"
+
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ env:
   - TARGET_DATABASES=MySQL DB_TYPE=MySQL MYSQL_HOST="127.0.0.1" MYSQL_PORT=3306 MYSQL_USER=root MYSQL_PASSWORD="" MYSQL_DB=testing
   - TARGET_DATABASES=SQLite3 DB_TYPE=SQLite3 SQLITE3_PATH=":memory:"
 
+install: make reqs
+
 script: make test

--- a/README.md
+++ b/README.md
@@ -68,9 +68,16 @@ Pending functionalities include but not limited to:
 
 More info in the issue page
 
-#### How to run tests locally
+### Tests
 
-The tests scripts in based on tests/config.yml file. Take a look at the tests/config.yml.orig and modify it to suite your need.
+#### Running tests from Travis CI:
+
+The project is integrated with [Travis CI][travis]. All required configurations have been placed in `.travis.yml`. Therefore, once you have forked the repository, all you need to do is simply [activate a Github webhook][activate-github-webhook]. See [Getting Started guide][travis-guide] for Travis CI.
+
+
+#### Running tests locally:
+
+To run tests locally requires you to manual configure some variables. These configurations values should be placed in `tests/config.yml` file. Simply copy `tests/config.yml.orig` to `tests/config.yml` and modify it to reflect correct values.
 
 
 ## license:
@@ -78,3 +85,8 @@ The tests scripts in based on tests/config.yml file. Take a look at the tests/co
 __The MIT License (MIT)__
 
 Copyright (c) 2014-2015 Taiyuan Zhang <zhangty10@gmail.com>
+
+
+[activate-github-webhook]:http://docs.travis-ci.com/user/getting-started/#Step-two%3A-Activate-GitHub-Webhook
+[travis]:https://travis-ci.org/
+[travis-guide]:http://docs.travis-ci.com/user/getting-started/

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ test:
 	python test.py
 
 reqs:
-	pip install -r requirements.txt --use-mirrors
+	pip install -r requirements.txt
 
 doc: install
 	cd doc; make clean; make html

--- a/makefile
+++ b/makefile
@@ -2,6 +2,9 @@
 test:
 	python test.py
 
+reqs:
+	pip install -r requirements.txt --use-mirrors
+
 doc: install
 	cd doc; make clean; make html
 
@@ -17,4 +20,4 @@ upload:
 clean:
 	rm monsql/*.pyc
 
-.PHONY: test install register upload clean
+.PHONY: test reqs install register upload clean

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+MySQL-python
+pyyaml

--- a/tests/base.py
+++ b/tests/base.py
@@ -28,7 +28,7 @@ class BaseTestCase(unittest.TestCase):
 
         if dbtype == DB_TYPES.MYSQL:
             self.monsql = MonSQL(host=config_data['MYSQL_HOST'], 
-                                 port=config_data['MYSQL_PORT'], 
+                                 port=int(config_data['MYSQL_PORT']), 
                                  username=config_data['MYSQL_USER'],
                                  password=config_data['MYSQL_PASSWORD'], 
                                  dbname=config_data['MYSQL_DB'], 


### PR DESCRIPTION
[Travis CI](https://travis-ci.org) offers free CI services for Open Source projects. It relies on [build configuration](http://docs.travis-ci.com/user/build-configuration/) specified in a `.travis.yml` file in the root of the repository. See [Getting Started with Travis CI](http://docs.travis-ci.com/user/getting-started/).

Some minor changes to the source files have made, notably:
- Reading Port number from environment returns it as a string. We require to convert it to an integer when calling `MySQLdb.Connect` &mdash; 9a97d5a
- A new Makefile target, `reqs`, allows manual installation of requirements such as `MySQL-python`. The requirements are stated per line in the `requirements.txt` file &mdash; 4850793
- We only ignore the `*.yml` files in the `tests/` directory.

After merge, you may want to include a [build status image](http://docs.travis-ci.com/user/status-images/) in the `README.md`
